### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chop
 
-Lazy, cancellable, progressive tasks with intuitive and lightweight resource management mechanism based on [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) concept. Easy-peasy testing included.
+Lazy, cancellable, progressive tasks with intuitive and lightweight resource management mechanism based on [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) concept. 174 SLOC. Easy-peasy testing.
 
 [![CI Status](https://travis-ci.org/ivanmoskalev/Chop.svg?branch=master)](https://travis-ci.org/ivanmoskalev/Chop)
 [![codecov.io](https://codecov.io/github/ivanmoskalev/Chop/coverage.svg?branch=master)](https://codecov.io/github/ivanmoskalev/Chop?branch=master)
@@ -10,12 +10,12 @@ Lazy, cancellable, progressive tasks with intuitive and lightweight resource man
 
 ## What is Chop?
 
-Chop is a Swift microframework providing two simple classes, which provide implementations async ***tasks*** and ***task groups***.
+Chop is a Swift microframework providing a simple implementations implementations async ***tasks*** and ***task groups***.
 
 - **Tasks** are abstractions over asynchronous processes that can yield several values during their lifetime (think of progressive images or cached-then-remote values). They can also finish with an error. Tasks are lazy – which means they are not started before they really need to. Furthermore, tasks are cancelled when they are no longer referenced (ie, deallocated), freeing up jobs and resources they are associated with.
 - **Task Groups** are execution contexts for tasks. They allow to place uniqueness constraints on tasks and apply a variety of behaviors around that (for example, replacing existing task with the same unique ID with the new one or ignoring the latter). Task Groups also free up all tasks they manage when they are deallocated, making them a nice way to particular tasks to, say, user interface. 
 
-Here is a small example of how Chop can be used to execute a task that progressively loads a collection of items (for example, first fetching the locally cached value, and then the remote value). As a nice bonus: subsequent similar tasks are ignored until the first one finishes:
+Here is a small example of how Chop can be used to execute a task that progressively loads a collection of items (for example, first fetching the locally cached value, and then the remote value). Only one task is allowed to execute; subsequent similar tasks are ignored until the first one finishes:
 ```swift
 // The context in which the tasks can execute. 
 // `policy` describes what should be done if a task with an identical `taskId` is added to group.
@@ -44,7 +44,10 @@ self.interactor
 
 Imagine how much boilerplate code would you have to write to acheive this behavior. With `Chop` it is easy, declarative and rather enjoyable. 
 
-The task performs work only as long as it is referenced by a `TaskGroup`. Consequently, if the `TaskGroup` is destroyed, all the tasks it manages are interrupted and you don't have to care about them anymore. 
+The task performs work only as long as it is referenced by a `TaskGroup`. Consequently, if the `TaskGroup` is destroyed, all the managed tasks are interrupted and you don't have to care about them anymore. 
+
+Also note the lack of `[weak self]` – if a `Task` is registered in a `TaskGroup`, it is automatically deallocated on completion, thus terminating a retain cycle. If you store references to `Task` somewhere else, be wary – you have to handle retain cycles yourself. 
+
 
 ## Requirements
 


### PR DESCRIPTION
- Clarify lack of `[weak self]` and the default retain cycle handling
- Fix typos